### PR TITLE
Add new regex to match longer issue keys

### DIFF
--- a/index.php
+++ b/index.php
@@ -95,7 +95,7 @@ $togglClientId = getenv('TOGGL_CLIENT_ID');
 				continue;
 			}
 
-			preg_match('#([A-Z]{2,3}-[0-9]*) #', $description, $matches);
+			preg_match('#(^[A-Z]*-[0-9]*) #', $description, $matches);
 
 			if ($matches) {
 				$issueKey = $matches[1];


### PR DESCRIPTION
The oldest regex did not match longer issue keys:

![screen shot 2018-05-18 at 12 43 55](https://user-images.githubusercontent.com/10577705/40244976-aff34ac4-5a9a-11e8-8cf7-95f814ee9a06.png)

I've changed it to match:
![screen shot 2018-05-18 at 12 44 09](https://user-images.githubusercontent.com/10577705/40245006-bcfd794c-5a9a-11e8-81f6-c422507c0827.png)
